### PR TITLE
Large Update // Complete Overhaul

### DIFF
--- a/NightZombies.cs
+++ b/NightZombies.cs
@@ -13,7 +13,7 @@ using Newtonsoft.Json;
 
 namespace Oxide.Plugins
 {
-    [Info("Night Zombies", "0x89A", "3.5.2")]
+    [Info("Night Zombies", "0x89A", "3.5.1")]
     [Description("Spawns and kills zombies at set times")]
     class NightZombies : RustPlugin
     {

--- a/NightZombies.cs
+++ b/NightZombies.cs
@@ -13,7 +13,7 @@ using Newtonsoft.Json;
 
 namespace Oxide.Plugins
 {
-    [Info("Night Zombies", "0x89A", "3.5.")]
+    [Info("Night Zombies", "0x89A", "3.5.2")]
     [Description("Spawns and kills zombies at set times")]
     class NightZombies : RustPlugin
     {

--- a/NightZombies.cs
+++ b/NightZombies.cs
@@ -13,7 +13,7 @@ using Newtonsoft.Json;
 
 namespace Oxide.Plugins
 {
-    [Info("Night Zombies", "0x89A", "3.4.2")]
+    [Info("Night Zombies", "0x89A", "3.5.2")]
     [Description("Spawns and kills zombies at set times")]
     class NightZombies : RustPlugin
     {

--- a/NightZombies.cs
+++ b/NightZombies.cs
@@ -368,7 +368,7 @@ namespace Oxide.Plugins
                 }
 
                 // Schedule removal of these forced zombies after 10 minutes (600 seconds)
-                timer.Once(600f, () =>
+                _instance.timer.Once(600f, () => {
                 {
                     foreach (ScarecrowNPC zombie in _zombies.ToArray())
                     {

--- a/NightZombies.cs
+++ b/NightZombies.cs
@@ -13,7 +13,7 @@ using Newtonsoft.Json;
 
 namespace Oxide.Plugins
 {
-    [Info("Night Zombies", "0x89A", "3.5.1")]
+    [Info("Night Zombies", "0x89A", "3.5.")]
     [Description("Spawns and kills zombies at set times")]
     class NightZombies : RustPlugin
     {
@@ -369,7 +369,6 @@ namespace Oxide.Plugins
 
                 // Schedule removal of these forced zombies after 10 minutes (600 seconds)
                 _instance.timer.Once(600f, () => {
-                {
                     foreach (ScarecrowNPC zombie in _zombies.ToArray())
                     {
                         if (zombie != null && !zombie.IsDestroyed)

--- a/NightZombies.cs
+++ b/NightZombies.cs
@@ -13,7 +13,7 @@ using Newtonsoft.Json;
 
 namespace Oxide.Plugins
 {
-    [Info("Night Zombies", "0x89A", "4.1.0")]
+    [Info("Night Zombies", "0x89A", "4.1.1")]
     [Description("Spawns and kills zombies at set times")]
     class NightZombies : RustPlugin
     {
@@ -674,7 +674,7 @@ namespace Oxide.Plugins
                 new Configuration.SpawnWave
                 {
                     WaveName = "Night Wave",
-                    Spawn Time = 19.8f,
+                    SpawnTime = 19.8f,
                     DestroyTime = 7.3f,
                     SpawnNearPlayers = true,
                     MinNearPlayers = 10,

--- a/NightZombies.cs
+++ b/NightZombies.cs
@@ -13,7 +13,7 @@ using Newtonsoft.Json;
 
 namespace Oxide.Plugins
 {
-    [Info("Night Zombies", "0x89A", "3.6.0")]
+    [Info("Night Zombies", "0x89A", "4.0.0")]
     [Description("Spawns and kills zombies at set times")]
     class NightZombies : RustPlugin
     {

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 * **Quick destroy corpses** - Are corpses cleaned up after 10 seconds.
 
 ## Permissions
-* **nightzombies.admin**: Allows users to execute the `/forcespawn` chat command.
+* **nightzombies.admin**: Allows users to execute the `/forcespawn` or `/despawnall` chat command.
 * **nightzombies.ignore**: Scarecrows will not attack players with this permission.
 
 ## Chat Commands

--- a/README.md
+++ b/README.md
@@ -64,10 +64,11 @@
 * **Quick destroy corpses** - Are corpses cleaned up after 10 seconds.
 
 ## Permissions
-- **nightzombies.admin**: Allows users to execute the `/forcespawn` chat command.
-- **nightzombies.ignore**: Scarecrows will not attack players with this permission.
+* **nightzombies.admin**: Allows users to execute the `/forcespawn` chat command.
+* **nightzombies.ignore**: Scarecrows will not attack players with this permission.
+
 ## Chat Commands
-- **/forcespawn**: Forces an immediate zombie spawn.
+* **/forcespawn**: Forces an immediate zombie spawn.
 
 ### Behaviour Settings
 

--- a/README.md
+++ b/README.md
@@ -2,34 +2,75 @@
 
 ```json
 {
-  "Spawn Settings": {
-    "Spawn near players": false,
-    "Min pop for near player spawn": 10,
-    "Min distance from player": 30.0,
-    "Max distance from player": 60.0,
-    "Spawn Time": 19.8,
-    "Destroy Time": 7.3,
-    "Zombie Settings": {
-      "Scarecrow Population (total amount)": 50,
-      "Scarecrow Health": 200.0,
-      "Scarecrow Kits": [
-        "kitname"
-      ]
+  "Spawn Waves": [
+    {
+      "Wave Name": "Night Wave",
+      "Spawn Time": 19.8,
+      "Destroy Time": 7.3,
+      "Spawn near players": true,
+      "Min pop for near player spawn": 10,
+      "Min distance from player": 30.0,
+      "Max distance from player": 60.0,
+      "Zombie Settings": {
+        "Display Name": "Scarecrow",
+        "Scarecrow Population (total amount)": 50,
+        "Scarecrow Health": 200.0,
+        "Scarecrow Kits": [ "defaultkit" ]
+      },
+      "Chance Settings": {
+        "Chance per cycle": 100.0,
+        "Days betewen spawn": 0
+      }
     },
-    "Chance Settings": {
-      "Chance per cycle": 100.0,
-      "Days betewen spawn": 0
+    {
+      "Wave Name": "Dawn Wave",
+      "Spawn Time": 6.0,
+      "Destroy Time": 8.0,
+      "Spawn near players": false,
+      "Min pop for near player spawn": 0,
+      "Min distance from player": 40.0,
+      "Max distance from player": 80.0,
+      "Zombie Settings": {
+        "Display Name": "Dawn Scarecrow",
+        "Scarecrow Population (total amount)": 30,
+        "Scarecrow Health": 150.0,
+        "Scarecrow Kits": [ "dawnkit" ]
+      },
+      "Chance Settings": {
+        "Chance per cycle": 50.0,
+        "Days betewen spawn": 1
+      }
+    },
+    {
+      "Wave Name": "Midnight Wave",
+      "Spawn Time": 0.0,
+      "Destroy Time": 1.0,
+      "Spawn near players": true,
+      "Min pop for near player spawn": 5,
+      "Min distance from player": 20.0,
+      "Max distance from player": 50.0,
+      "Zombie Settings": {
+        "Display Name": "Midnight Scarecrow",
+        "Scarecrow Population (total amount)": 40,
+        "Scarecrow Health": 180.0,
+        "Scarecrow Kits": [ "midnightkit" ]
+      },
+      "Chance Settings": {
+        "Chance per cycle": 75.0,
+        "Days betewen spawn": 0
+      }
     }
-  },
+  ],
   "Destroy Settings": {
-    "Leave Corpse, when destroyed (can cause more lag if true)": false,
+    "Leave Corpse, when destroyed": false,
     "Leave Corpse, when killed by player": true,
-    "Half body bag despawn time": true,
-    "Quick destroy corpses": true
+    "Spawn Loot": true,
+    "Half bodybag despawn time": true
   },
   "Behaviour Settings": {
     "Attack sleeping players": false,
     "Zombies attacked by outpost sentries": true,
+    "Throw Grenades": true,
     "Ignore Human NPCs": true,
     "Ignored entities (full entity shortname)": [
       "scientistjunkpile.prefab",
@@ -37,7 +78,7 @@
     ]
   },
   "Broadcast Settings": {
-    "Broadcast spawn amount": false,
+    "Broadcast spawn amount": false
   }
 }
 ```
@@ -50,6 +91,25 @@
 * **Max distance from player** - When spawning near players, this is the maximum distance that zombies are allowed to spawn from the player.
 * **Spawn Time** - The in-game time at which zombies will appear.
 * **Destroy Time** - The in-game time at which zombies will disappear.
+
+### Spawn Waves
+* **Wave Name - A unique name for the spawn wave.
+* **Spawn Time - The in-game time at which this wave of zombies will appear.
+* **Destroy Time - The in-game time at which zombies in this wave will be despawned.
+* **Spawn near players - Determines whether zombies in this wave will spawn near players (if true) or randomly around the map.
+* **Min pop for near player spawn - Minimum number of players on the server for a near-player spawn to occur.
+* **Min distance from player - The minimum allowed distance for zombies to spawn from a player.
+* **Max distance from player - The maximum allowed distance for zombies to spawn from a player.
+
+### Wave-Specific Settings
+* Zombie Settings
+  * **Display Name – The name shown for zombies in this wave.
+  * **Scarecrow Population (total amount) – Total number of zombies to spawn in this wave.
+  * **Scarecrow Health – Health value for each zombie in this wave.
+  * **Scarecrow Kits – A list of kits to assign to zombies (if applicable).
+* Chance Settings
+  * **Chance per cycle – The percentage chance that zombies in this wave will spawn each spawn attempt.
+  * **Days betewen spawn – The number of days between spawn attempts (if you want to throttle spawning over time).
 
 #### Chance Settings
 
@@ -69,6 +129,7 @@
 
 ## Chat Commands
 * **/forcespawn**: Forces an immediate zombie spawn.
+* **/despawnall**: Immediately despawns all zombies (and their corpses) across all spawn waves. Requires the nightzombies.admin permission.
 
 ### Behaviour Settings
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,51 @@
 ## Configuration
 
+### Spawn Settings
+* **Spawn near players** - Do zombies spawn near to players (randomly chosen), if false zombies will spawn randomly around the map.
+* **Min pop for near player spawn** - The minimum number of players on the server for zombies to spawn near players.
+* **Min distance from player** - When spawning near players, this is the minimum distance that zombies are allowed to spawn from the player.
+* **Max distance from player** - When spawning near players, this is the maximum distance that zombies are allowed to spawn from the player.
+* **Spawn Time** - The in-game time at which zombies will appear.
+* **Destroy Time** - The in-game time at which zombies will disappear.
+
+### Spawn Waves
+* **Wave Name** - A unique name for the spawn wave.
+* **Spawn Time** - The in-game time at which this wave of zombies will appear.
+* **Destroy Time** - The in-game time at which zombies in this wave will be despawned.
+* **Spawn near players** - Determines whether zombies in this wave will spawn near players (if true) or randomly around the map.
+* **Min pop for near player spawn** - Minimum number of players on the server for a near-player spawn to occur.
+* **Min distance from player** - The minimum allowed distance for zombies to spawn from a player.
+* **Max distance from player** - The maximum allowed distance for zombies to spawn from a player.
+
+### Wave-Specific Settings
+* Zombie Settings
+  * **Display Name** – The name shown for zombies in this wave.
+  * **Scarecrow Population (total amount)** – Total number of zombies to spawn in this wave.
+  * **Scarecrow Health** – Health value for each zombie in this wave.
+  * **Scarecrow Kits** – A list of kits to assign to zombies (if applicable).
+* Chance Settings
+  * **Chance per cycle** – The percentage chance that zombies in this wave will spawn each spawn attempt.
+  * **Days betewen spawn** – The number of days between spawn attempts (if you want to throttle spawning over time).
+
+### Destroy Settings
+* **Leave Corpse, when destroyed** - Are corpses left when zombies disappear (can affect performance when set to true).
+* **Leave Corpse, when killed by player** - Are corpses left when zombies are killed by players.
+* **Half body bag despawn time** - Is the despawn time for green loot backpacks halved.
+* **Quick destroy corpses** - Are corpses cleaned up after 10 seconds.
+
+## Permissions
+* **nightzombies.admin**: Allows users to execute the `/forcespawn` chat command.
+* **nightzombies.ignore**: Scarecrows will not attack players with this permission.
+
+## Chat Commands
+* **/forcespawn**: Forces an immediate zombie spawn.
+* **/despawnall**: Immediately despawns all zombies (and their corpses) across all spawn waves. Requires the nightzombies.admin permission.
+
+### Behaviour Settings
+* **Zombies attacked by outpost sentries** - Are zombies attacked by the sentries at safezones.
+* **Ignore Human NPCs** - Do zombies ignore npc player characters.
+* **Ignored entities (full entity shortname)** - Zombies will not target entities in this list, must be the full short prefab name.
+
 ```json
 {
   "Spawn Waves": [
@@ -82,63 +128,7 @@
   }
 }
 ```
-
-### Spawn Settings
-
-* **Spawn near players** - Do zombies spawn near to players (randomly chosen), if false zombies will spawn randomly around the map.
-* **Min pop for near player spawn** - The minimum number of players on the server for zombies to spawn near players.
-* **Min distance from player** - When spawning near players, this is the minimum distance that zombies are allowed to spawn from the player.
-* **Max distance from player** - When spawning near players, this is the maximum distance that zombies are allowed to spawn from the player.
-* **Spawn Time** - The in-game time at which zombies will appear.
-* **Destroy Time** - The in-game time at which zombies will disappear.
-
-### Spawn Waves
-* **Wave Name - A unique name for the spawn wave.
-* **Spawn Time - The in-game time at which this wave of zombies will appear.
-* **Destroy Time - The in-game time at which zombies in this wave will be despawned.
-* **Spawn near players - Determines whether zombies in this wave will spawn near players (if true) or randomly around the map.
-* **Min pop for near player spawn - Minimum number of players on the server for a near-player spawn to occur.
-* **Min distance from player - The minimum allowed distance for zombies to spawn from a player.
-* **Max distance from player - The maximum allowed distance for zombies to spawn from a player.
-
-### Wave-Specific Settings
-* Zombie Settings
-  * **Display Name – The name shown for zombies in this wave.
-  * **Scarecrow Population (total amount) – Total number of zombies to spawn in this wave.
-  * **Scarecrow Health – Health value for each zombie in this wave.
-  * **Scarecrow Kits – A list of kits to assign to zombies (if applicable).
-* Chance Settings
-  * **Chance per cycle – The percentage chance that zombies in this wave will spawn each spawn attempt.
-  * **Days betewen spawn – The number of days between spawn attempts (if you want to throttle spawning over time).
-
-#### Chance Settings
-
-* **Chance per cycle** - Percentage chance that zombies will spawn each spawn attempt.
-* **Days between spawn** - The number of days between spawn attempts.
-
-### Destroy Settings
-
-* **Leave Corpse, when destroyed** - Are corpses left when zombies disappear (can affect performance when set to true).
-* **Leave Corpse, when killed by player** - Are corpses left when zombies are killed by players.
-* **Half body bag despawn time** - Is the despawn time for green loot backpacks halved.
-* **Quick destroy corpses** - Are corpses cleaned up after 10 seconds.
-
-## Permissions
-* **nightzombies.admin**: Allows users to execute the `/forcespawn` chat command.
-* **nightzombies.ignore**: Scarecrows will not attack players with this permission.
-
-## Chat Commands
-* **/forcespawn**: Forces an immediate zombie spawn.
-* **/despawnall**: Immediately despawns all zombies (and their corpses) across all spawn waves. Requires the nightzombies.admin permission.
-
-### Behaviour Settings
-
-* **Zombies attacked by outpost sentries** - Are zombies attacked by the sentries at safezones.
-* **Ignore Human NPCs** - Do zombies ignore npc player characters.
-* **Ignored entities (full entity shortname)** - Zombies will not target entities in this list, must be the full short prefab name.
-
 ## Notes
-
 **These are likely broken after the large AI update 2nd December 2021**
 
 The 0.9.0 and 2.0 versions are still available to download if you want them.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@
 * **Half body bag despawn time** - Is the despawn time for green loot backpacks halved.
 * **Quick destroy corpses** - Are corpses cleaned up after 10 seconds.
 
+## Permissions
+- **nightzombies.admin**: Allows users to execute the `/forcespawn` chat command.
+- **nightzombies.ignore**: Scarecrows will not attack players with this permission.
+## Chat Commands
+- **/forcespawn**: Forces an immediate zombie spawn.
+
 ### Behaviour Settings
 
 * **Zombies attacked by outpost sentries** - Are zombies attacked by the sentries at safezones.


### PR DESCRIPTION
There weren't a lot of debug commands or the availability to have multiple spawn waves.
This involved me having to redo the spawning functionality to support multiple wave types completely.

Primary features:
spawn waves:
allows the user to make multiple groupings of spawns so you can have one wave spawn at 4 am-6 am and another 9 am-12 pm for example whilst having all of their settings
the user can also add more than the config provides on a default. The plural amount in there is mainly for example.

From my testing the plugin behaves for the player exactly the same.
Please let me know if there's an issue, and I can revise it before a merge occurs as this is my first time fully working with oxide so it's a bit of a learning curve.